### PR TITLE
Output more accurate time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"chalk": "^2.0.0",
 		"figures": "^2",
 		"mkdirp-then": "^1.2",
+		"ms": "^2.0.0",
 		"pretty-ms": "^5.0.0",
 		"mz": "^2.7.0",
 		"pad-left": "^2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"chalk": "^2.0.0",
 		"figures": "^2",
 		"mkdirp-then": "^1.2",
-		"ms": "^2.0.0",
+		"pretty-ms": "^5.0.0",
 		"mz": "^2.7.0",
 		"pad-left": "^2.1",
 		"pad-right": "^0.2.2",

--- a/track.js
+++ b/track.js
@@ -5,7 +5,7 @@ const chalk =   require('chalk')
 const figures = require('figures')
 const lPad =    require('pad-left')
 const rPad =    require('pad-right')
-const ms =      require('ms')
+const ms =      require('pretty-ms')
 const yargs =   require('yargs')
 
 const track =   require('./index')()

--- a/track.js
+++ b/track.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 'use strict'
 
-const chalk =   require('chalk')
-const figures = require('figures')
-const lPad =    require('pad-left')
-const rPad =    require('pad-right')
-const ms =      require('pretty-ms')
-const yargs =   require('yargs')
+const chalk =    require('chalk')
+const figures =  require('figures')
+const lPad =     require('pad-left')
+const rPad =     require('pad-right')
+const ms =       require('ms')
+const prettyms = require('pretty-ms')
+const yargs =    require('yargs')
 
-const track =   require('./index')()
+const track =    require('./index')()
 
 const symbols = {
 	started:  chalk.green(figures.play),
@@ -142,11 +143,11 @@ const statusOfTracker = (tracker) => {
 	let elapsed = tracker.started ? Date.now() - tracker.started : 0
 	let output = [
 		lPad(chalk.underline(tracker.name), 25),
-		rPad(chalk.cyan(ms(tracker.value + elapsed)), 15, ' ')
+		rPad(chalk.cyan(prettyms(tracker.value + elapsed, {unitCount: 2})), 15, ' ')
 	]
 	if (tracker.started) {
 		const started = new Date(tracker.started)
-		output.push(symbols.started, ms(elapsed))
+		output.push(symbols.started, prettyms(elapsed, {unitCount: 2}))
 		if (new Date().toDateString() !== started.toDateString())
 			output.push(chalk.gray(started.toLocaleDateString()))
 		output.push(chalk.gray(started.toLocaleTimeString()))


### PR DESCRIPTION
Currently when running `track s` you will get an output like `some-job 2h`, but with further inspection of the actual ms it's more like 2.5 hours.

I found simply replacing ms with pretty-ms changes the output to be `2h 25m 15.6s`, which is more like the output I'd want.